### PR TITLE
docs: git tags available for semantic release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Add **release** field to your **package.json** as described at [plugins document
 }
 ```
 
+Make sure your travis build fetches your git tags before running `semantic-release`. If you have no special `git` commands in your `.travis.yml` file, add `git fetch --tags` to your `after_success` section like this:
+```yaml
+after_success:
+  - git fetch --tags
+  - npm run semantic-release
+```
+
 Create the first git tag manually and push it:
 ```sh
 git tag v0.0.0


### PR DESCRIPTION
Adds a section to `README.md` based on https://github.com/finom/last-release-git/issues/2.
Suggests a way to fetch tags in travis before running `npm run semantic-release` to avoid lacking tags.