### PR TITLE
Fix Travis setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Add **release** field to your **package.json** as described at [plugins document
 }
 ```
 
-Make sure your travis build fetches your git tags before running `semantic-release`. If you have no special `git` commands in your `.travis.yml` file, add `git fetch --tags` to your `after_success` section like this:
+Make sure your travis build fetches your git tags before running `semantic-release`. If you have no special `git` commands in your `.travis.yml` file, make sure to fetch all tags in your `after_success` section like this:
 ```yaml
 after_success:
+  - git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
   - git fetch --tags
   - npm run semantic-release
 ```


### PR DESCRIPTION
Travis does a shallow clone of just a single branch, which means `git fetch --tags` doesn't fetch all tags.

See https://stackoverflow.com/questions/17714159/how-do-i-undo-a-single-branch-clone

I can confirm this works in https://github.com/felixfbecker/php-language-server/blob/master/.travis.yml